### PR TITLE
Clean up quote implementation

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,7 +9,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   # Minimum supported Rust version (MSRV)
-  ACTION_MSRV_TOOLCHAIN: 1.49.0
+  ACTION_MSRV_TOOLCHAIN: 1.52.0
   # Pinned toolchain for linting
   ACTION_LINTS_TOOLCHAIN: 1.53.0
 

--- a/src/internals.rs
+++ b/src/internals.rs
@@ -20,11 +20,11 @@ fn shell_quote(value: &str) -> String {
 
 // https://wiki.bash-hackers.org/syntax/quoting#ansi_c_like_strings
 fn bash_binary_quote(value: &[u8]) -> String {
-    let mut r = Vec::new();
-    r.extend(b"$'".iter());
-    r.extend(value.iter().flat_map(|&c| std::ascii::escape_default(c)));
-    r.extend(b"'".iter());
-    String::from_utf8(r).expect("bash_binary quote should have output utf8")
+    let value = value
+        .iter()
+        .flat_map(|&c| std::ascii::escape_default(c))
+        .flat_map(|c| char::from_u32(c as u32));
+    "$'".chars().chain(value).chain("'".chars()).collect()
 }
 
 impl fmt::Display for CommandArg {
@@ -196,4 +196,21 @@ pub fn execute(mut cmd: Command) -> Result<(), std::io::Error> {
         ));
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn quote() {
+        let strs = [("$''", ""), ("$'foo bar'", "foo bar"), (r"$'\\n'", r"\n")];
+        for (k, v) in strs.iter() {
+            assert_eq!(*k, bash_binary_quote(v.as_bytes()));
+        }
+        let bins = [(r"$'foo\x07bar'", b"foo\x07bar")];
+        for (k, v) in bins.iter() {
+            assert_eq!(*k, bash_binary_quote(*v));
+        }
+    }
 }


### PR DESCRIPTION
No need to do an `unwrap()` here.  Just noticed while
reading the code.  That said, I think there
should be an unwrap-free method to go from `u8` -> `char`.