### PR TITLE
docs: Link to xshell

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,13 @@
 //! foo="variable with spaces"
 //! test ${foo} = 'variable with spaces'
 //! ```
+//!
+//! # Related crates
+//!
+//! [`xshell`] is a crate that does not depend on bash, and also supports
+//! inline formatting.
+//!
+//! [`xshell`]: https://docs.rs/xshell/latest/xshell/
 
 #[doc(hidden)]
 pub mod internals;


### PR DESCRIPTION
I think where that's going long term is better than this; may
end up deprecating this crate.